### PR TITLE
Fix config path to avoid exception

### DIFF
--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -46,7 +46,7 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function setUpConfig(): void
     {
-        $source = dirname(__DIR__) . '/config/easy-rsa.php';
+        $source = dirname(dirname(__DIR__)) . '/config/easy-rsa.php';
 
         if ($this->app instanceof LaravelApplication) {
             $this->publishes([$source => config_path('easy-rsa.php')], 'config');


### PR DESCRIPTION
Symfony\Component\ErrorHandler\Error\FatalError 
Illuminate\Support\ServiceProvider::mergeConfigFrom(): Failed opening required '/home/www-data/gw/vendor/evilfreelancer/easyrsa-php/src/config/easy-rsa.php'